### PR TITLE
[Internal Code Review] C1X adapter for Prebid v1.0

### DIFF
--- a/integrationExamples/gpt/c1x-prebid-cathytest.html
+++ b/integrationExamples/gpt/c1x-prebid-cathytest.html
@@ -80,9 +80,11 @@
                   {
                       bidder: 'c1x',
                       params: {
+                        siteId: '9999',
+                        pixelId: '12345',
                         floorPriceMap: {
-                          '300x250': 4.00,
-                          '300x600': 3.00
+                          '300x250': 0.20,
+                          '300x600': 0.30
                         }, //optional
                       }
                   }
@@ -96,9 +98,10 @@
                   {
                       bidder: 'c1x',
                       params: {
+                        siteId: '9999',
                         placementID: "234234",
                         floorPriceMap: {
-                          '300x600': 3.00
+                          '300x600': 0.40
                         }
                       }
                   }
@@ -145,12 +148,6 @@
         }
       };
 
-      // Use our own tag instead of pbjs bidder settings
-      window.c1x_pubtag = {
-        siteId: '9999',
-        pixelId: '12345', //optional
-        endpoint: 'http://ht-integration.c1exchange.com:9000/ht', //optional,
-      };
 
       /* Request bids for the added ad units. If adUnits or adUnitCodes are
        not specified, the function will request bids for all added ad units.

--- a/integrationExamples/gpt/c1x-prebid-cathytest.html
+++ b/integrationExamples/gpt/c1x-prebid-cathytest.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Prebid.js integration example</title>
+<script>
+    var PREBID_TIMEOUT = 8000;
+    var MAX_RETRIES = 20;
+
+    var googletag = googletag || {};
+    googletag.cmd = googletag.cmd || [];
+    googletag.cmd.push(function () {
+        googletag.pubads().disableInitialLoad();
+    });
+
+    var pbjs = pbjs || {};
+    pbjs.cmd = pbjs.cmd || [];
+    pbjs.retries = 0;
+
+    /* pbjs.initAdserver will be called either when all bids are back, or
+     when the timeout is reached.
+     */
+    function initAdserver() {
+      if (pbjs.initAdserverSet) return;
+      if(!googletag.pubadsReady && pbjs.retries <= MAX_RETRIES) {
+          setTimeout(initAdserver, 500); //poll ms can be adjusted as desired.
+          pbjs.retries++;
+          return;
+      }
+      googletag.cmd.push(function () {
+        pbjs.cmd.push(function () {
+            pbjs.setTargetingForGPTAsync();
+        });
+        googletag.pubads().refresh();
+      });
+      pbjs.initAdserverSet = true;
+    }
+
+    // Load GPT when timeout is reached.
+    setTimeout(initAdserver, PREBID_TIMEOUT);
+
+    // Load the Prebid Javascript Library Async. We recommend loading it immediately after the initAdserver() and setTimeout functions.
+    (function() {
+        var d = document, pbs = d.createElement('script'), pro = d.location.protocol;
+        pbs.type = 'text/javascript';
+        pbs.src = '../../build/dev/prebid.js';
+        var target = document.getElementsByTagName('head')[0];
+        target.insertBefore(pbs, target.firstChild);
+    })();
+
+    //load GPT library here
+    (function () {
+        var gads = document.createElement('script');
+        gads.async = true;
+        gads.type = 'text/javascript';
+        var useSSL = 'https:' == document.location.protocol;
+        gads.src = (useSSL ? 'https:' : 'http:') +
+                '//www.googletagservices.com/tag/js/gpt.js';
+        var node = document.getElementsByTagName('script')[0];
+        node.parentNode.insertBefore(gads, node);
+    })();
+
+    pbjs.cmd.push(function () {
+
+      /* 1. Register bidder tag Ids
+
+       Registers the bidder tags for your ad units. Once the prebid.js
+       library loads, it reads the pbjs.adUnits object and sends out
+       bid requests. 
+
+       code:  Your GPT slot’s ad unit path. If they don’t match, prebid.js
+       would not be able to set targeting correctly
+       sizes: All sizes your ad unit accepts. They should match with GPT.
+       */
+      var adUnits = [
+          {
+              code: 'div-gpt-ad-1498193081995-0',
+              sizes: [[300, 600], [300, 250]],
+              bids: [
+                  // 1 ad unit can be targeted by multiple bids.
+                  {
+                      bidder: 'c1x',
+                      params: {
+                        floorPriceMap: {
+                          '300x250': 4.00,
+                          '300x600': 3.00
+                        }, //optional
+                      }
+                  }
+              ]
+          },
+          {
+              code: 'div-gpt-ad-test',
+              sizes: [[300, 600]],
+              bids: [
+                  // 1 ad unit can be targeted by multiple bids.
+                  {
+                      bidder: 'c1x',
+                      params: {
+                        placementID: "234234",
+                        floorPriceMap: {
+                          '300x600': 3.00
+                        }
+                      }
+                  }
+              ]
+          },
+      ];
+
+      //add the adUnits
+      pbjs.addAdUnits(adUnits);
+
+      //register a callback handler
+      pbjs.onEvent('bidResponse', function (bidResponse) {
+          console.log('A bid response has arrived:');
+      });
+
+     /* Configure Ad Server Targeting
+       The below section defines what key value targeting will be sent to GPT.
+       */
+      pbjs.bidderSettings = {
+        standard: {
+          adserverTargeting: [
+            {
+                key: "hb_bidder",
+                val: function (bidResponse) {
+                    return bidResponse.bidderCode;
+                }
+            }, {
+                key: "hb_adid",
+                val: function (bidResponse) {
+                    return bidResponse.adId;
+                }
+            }, {
+                key: "hb_pb",
+                val: function (bidResponse) {
+                    return bidResponse.pbMg;
+                }
+            }, {
+                key: 'hb_size',
+                val: function (bidResponse) {
+                    return bidResponse.size;
+                }
+            }
+          ]
+        }
+      };
+
+      // Use our own tag instead of pbjs bidder settings
+      window.c1x_pubtag = {
+        siteId: '9999',
+        pixelId: '12345', //optional
+        endpoint: 'http://ht-integration.c1exchange.com:9000/ht', //optional,
+      };
+
+      /* Request bids for the added ad units. If adUnits or adUnitCodes are
+       not specified, the function will request bids for all added ad units.
+       */
+      pbjs.requestBids({
+
+          /* The bidsBack function will be called when either timeout is
+           reached, or when all bids come back, whichever happens sooner.
+           */
+          bidsBackHandler: function (bidResponses) {
+              // c1x.logs.push([new Date().getTime(), 'Bids back handler called.']);
+              console.log('all the bid responses are back');
+              console.log(bidResponses);
+              initAdserver();
+          }
+      });
+ 
+    });
+
+  googletag.cmd.push(function() {
+    googletag.defineSlot('/188708772/cathy-test-unit', [[300, 250], [300, 600]], 'div-gpt-ad-1498193081995-0').addService(googletag.pubads());
+    googletag.pubads().enableSingleRequest();
+    googletag.enableServices();
+  });
+
+</script>
+
+</head>
+<body>
+
+  <h2>Prebid.js Test</h2>
+
+  <!-- /188708772/cathy-test-unit -->
+  <div id='div-gpt-ad-1498193081995-0'>
+    <script type='text/javascript'>
+    googletag.cmd.push(function() { googletag.display('div-gpt-ad-1498193081995-0'); });
+    </script>
+  </div>
+
+</body>
+
+</html>

--- a/modules/c1xBidAdapter.js
+++ b/modules/c1xBidAdapter.js
@@ -16,32 +16,34 @@ export const c1xAdapter = {
   // check the bids sent to c1x bidder
   isBidRequestValid: function(bid) {
     const siteId = window.c1x_pubtag.siteId || '';
-
     return (bid.adUnitCode && siteId);
   },
 
   buildRequests: function(bidRequests) {
     let payload = {};
+    let tagObj = {};
     const siteId = window.c1x_pubtag.siteId || '';
     const adunits = bidRequests.length;
     const rid = new Date().getTime();
 
     const c1xTags = bidRequests.map(bidToTag);
-    console.log('Show C1X Tags');
-    console.log(c1xTags);
+
+    // flattened tags in a tag object
+    tagObj = c1xTags.reduce((current, next) => Object.assign(current, next));
+    console.log(tagObj);
 
     payload = {
       siteId: siteId,
-      adunits: adunits,
-      rid: rid,
+      adunits: adunits.toString(),
+      rid: rid.toString(),
     }
+    Object.assign(payload, tagObj);
+    console.log(payload);
 
-    console.log(bidRequests);
-    let payloadString = 'site=1&adunits=1&a1=banner1&a1s=[728x90]&rid=1452866810&a1t=i&a1p=1.5';
-    payloadString = JSON.stringify(c1xTags);
-    console.log('Show Payload String: ');
+    let payloadString = stringifyPayload(payload);
     console.log(payloadString);
 
+    // ServerRequest object
     return {
       method: 'GET',
       url: URL,
@@ -82,6 +84,16 @@ function bidToTag(bid, index) {
   tag[sizeKey] = sizesArr.reduce((prev, current) => prev + (prev === '' ? '' : ',') + current.join('x'), '');
 
   return tag;
+}
+
+function stringifyPayload(payload) {
+  let payloadString = '';
+  payloadString = JSON.stringify(payload).replace(/":"|","|{"|"}/g, (foundChar) => {
+    if (foundChar == '":"') return '=';
+    else if (foundChar == '","') return '&';
+    else return '';
+  });
+  return payloadString;
 }
 
 registerBidder(c1xAdapter);

--- a/modules/c1xBidAdapter.js
+++ b/modules/c1xBidAdapter.js
@@ -4,6 +4,8 @@ import { registerBidder } from 'src/adapters/bidderFactory';
 
 const BIDDER_CODE = 'c1x';
 const URL = 'http://ht-integration.c1exchange.com:9000/ht';
+const PIXEL_ENDPOINT = '//px.c1exchange.com/pubpixel/';
+const PIXEL_FIRE_DELAY = 3000;
 
 /**
  * Adapter for requesting bids from C1X header tag server.
@@ -52,7 +54,7 @@ export const c1xAdapter = {
   },
 
   // TO DO: Get JSON Responses from our bidder endpoint
-  interpretResponse: function(serverResponse, request) {
+  interpretResponse: function(serverResponse) {
     const bidResponses = [];
     const bidResponse = {
       requestId: '22222', // bidRequest.bidId,
@@ -71,13 +73,26 @@ export const c1xAdapter = {
     return bidResponses;
   },
 
-  getUserSyncs: function(syncOptions) {}
+  // Register pixels
+  getUserSyncs: function(syncOptions) {
+    const pixelId = window.c1x_pubtag.pixelId || '';
+    window.setTimeout(function() {
+      let pixel = document.createElement('img');
+      pixel.width = 1;
+      pixel.height = 1;
+      pixel.style = 'display:none;';
+      const useSSL = document.location.protocol;
+      pixel.src = (useSSL ? 'https:' : 'http:') + PIXEL_ENDPOINT + pixelId;
+      document.body.insertBefore(pixel, null);
+    }, PIXEL_FIRE_DELAY);
+  }
 }
 
 function bidToTag(bid, index) {
   const tag = {};
   const adIndex = 'a' + (index + 1).toString(); // ad unit id for c1x
   const sizeKey = adIndex + 's';
+  // TODO: Floor Price, Ad Unit Types
   // const priceKey = adIndex + 'p';
   const sizesArr = bid.sizes;
   tag[adIndex] = bid.adUnitCode;

--- a/modules/c1xBidAdapter.js
+++ b/modules/c1xBidAdapter.js
@@ -32,7 +32,6 @@ export const c1xAdapter = {
 
     // flattened tags in a tag object
     tagObj = c1xTags.reduce((current, next) => Object.assign(current, next));
-    console.log(tagObj);
 
     payload = {
       siteId: siteId,
@@ -94,11 +93,22 @@ function bidToTag(bid, index) {
   const tag = {};
   const adIndex = 'a' + (index + 1).toString(); // ad unit id for c1x
   const sizeKey = adIndex + 's';
-  // TODO: Floor Price, Ad Unit Types
-  // const priceKey = adIndex + 'p';
+  const priceKey = adIndex + 'p';
+  // TODO: Multiple Floor Prices
+
   const sizesArr = bid.sizes;
+  const floorPriceMap = bid.params.floorPriceMap || '';
   tag[adIndex] = bid.adUnitCode;
   tag[sizeKey] = sizesArr.reduce((prev, current) => prev + (prev === '' ? '' : ',') + current.join('x'), '');
+
+  const newSizeArr = tag[sizeKey].split(',');
+  if(floorPriceMap) {
+    newSizeArr.forEach( size => {
+      if(size in floorPriceMap) {
+        tag[priceKey] = floorPriceMap[size];
+      } // we only accept one cpm price in floorPriceMap
+    });
+  }
 
   return tag;
 }

--- a/modules/c1xBidAdapter.js
+++ b/modules/c1xBidAdapter.js
@@ -24,7 +24,7 @@ export const c1xAdapter = {
   // check the bids sent to c1x bidder
   isBidRequestValid: function(bid) {
     const siteId = bid.params.siteId || '';
-    if (siteId) {
+    if (!siteId) {
       utils.logError(LOG_MSG.noSite);
     }
     return !!(bid.adUnitCode && siteId);
@@ -50,7 +50,6 @@ export const c1xAdapter = {
       compress: 'gzip'
     }
     Object.assign(payload, tagObj);
-    console.log(payload);
 
     let payloadString = stringifyPayload(payload);
 
@@ -155,6 +154,7 @@ function bidToShortTag(bid) {
 
 function stringifyPayload(payload) {
   let payloadString = '';
+  console.log(payload);
   payloadString = JSON.stringify(payload).replace(/":"|","|{"|"}/g, (foundChar) => {
     if (foundChar == '":"') return '=';
     else if (foundChar == '","') return '&';

--- a/modules/c1xBidAdapter.js
+++ b/modules/c1xBidAdapter.js
@@ -3,7 +3,7 @@ import { registerBidder } from 'src/adapters/bidderFactory';
 // import * as utils from 'src/utils';
 
 const BIDDER_CODE = 'c1x';
-const URL = 'http://ht-integration.c1exchange.com:9000/ht';
+const URL = 'http://13.58.47.152:8080/ht';
 const PIXEL_ENDPOINT = '//px.c1exchange.com/pubpixel/';
 const PIXEL_FIRE_DELAY = 3000;
 
@@ -38,6 +38,8 @@ export const c1xAdapter = {
       siteId: siteId,
       adunits: adunits.toString(),
       rid: rid.toString(),
+      response: 'json',
+      compress: 'gzip'
     }
     Object.assign(payload, tagObj);
     console.log(payload);
@@ -73,7 +75,7 @@ export const c1xAdapter = {
     return bidResponses;
   },
 
-  // Register pixels
+  // Register user-sync pixels
   getUserSyncs: function(syncOptions) {
     const pixelId = window.c1x_pubtag.pixelId || '';
     window.setTimeout(function() {

--- a/modules/c1xBidAdapter.js
+++ b/modules/c1xBidAdapter.js
@@ -69,7 +69,7 @@ export const c1xAdapter = {
 
   interpretResponse: function(serverResponse, requests) {
     serverResponse = serverResponse.body;
-    requests = requests.bids;
+    requests = requests.bids || [];
     const currency = 'USD';
     const bidResponses = [];
 

--- a/modules/c1xBidAdapter.js
+++ b/modules/c1xBidAdapter.js
@@ -4,7 +4,7 @@ import * as utils from 'src/utils';
 import { userSync } from 'src/userSync';
 
 const BIDDER_CODE = 'c1x';
-const URL = 'http://13.58.47.152:8080/ht';
+const URL = 'http://18.217.214.190:8080/ht';
 const PIXEL_ENDPOINT = '//px.c1exchange.com/pubpixel/';
 const LOG_MSG = {
   invalidBid: 'C1X: [ERROR] bidder returns an invalid bid',
@@ -72,15 +72,18 @@ export const c1xAdapter = {
     requests = requests.bids || [];
     const currency = 'USD';
     const bidResponses = [];
+    let netRevenue = false;
 
     if (!serverResponse || serverResponse.error) {
       let errorMessage = serverResponse.error;
       utils.logError(LOG_MSG.invalidBid + errorMessage);
       return bidResponses;
     } else {
-      console.log(serverResponse);
       serverResponse.forEach(bid => {
         if (bid.bid) {
+          if (bid.bidType === 'NET_BID') {
+            netRevenue = !netRevenue;
+          }
           const curBid = {
             width: bid.width,
             height: bid.height,
@@ -89,7 +92,7 @@ export const c1xAdapter = {
             creativeId: bid.crid,
             currency: currency,
             ttl: 300,
-            netRevenue: false, // net or gross?
+            netRevenue: netRevenue
           };
 
           for (let i = 0; i < requests.length; i++) {

--- a/modules/c1xBidAdapter.js
+++ b/modules/c1xBidAdapter.js
@@ -1,155 +1,87 @@
-import CONSTANTS from 'src/constants.json';
-import utils from 'src/utils.js';
-import bidfactory from 'src/bidfactory.js';
-import bidmanager from 'src/bidmanager.js';
-import adloader from 'src/adloader';
-var adaptermanager = require('src/adaptermanager.js');
+// import CONSTANTS from 'src/constants.json';
+import { registerBidder } from 'src/adapters/bidderFactory';
+// import * as utils from 'src/utils';
+
+const BIDDER_CODE = 'c1x';
+const URL = 'http://ht-integration.c1exchange.com:9000/ht';
 
 /**
  * Adapter for requesting bids from C1X header tag server.
- * v2.0 (c) C1X Inc., 2017
- *
- * @param {Object} options - Configuration options for C1X
- *
- * @returns {{callBids: _callBids}}
- * @constructor
+ * v3.0 (c) C1X Inc., 2017
  */
-function C1XAdapter() {
-  // default endpoint. Can be overridden by adding an "endpoint" property to the first param in bidder config.
-  var ENDPOINT = 'http://ht-integration.c1exchange.com:9000/ht';
-  var PIXEL_ENDPOINT = '//px.c1exchange.com/pubpixel/';
-  var PIXEL_FIRE_DELAY = 3000;
-  var LOG_MSG = {
-    invalidBid: 'C1X: ERROR bidder returns an invalid bid',
-    noSite: 'C1X: ERROR no site id supplied',
-    noBid: 'C1X: INFO creating a NO bid for Adunit: ',
-    bidWin: 'C1X: INFO creating a bid for Adunit: '
-  };
-  var BIDDER_CODE = 'c1x';
 
-  var pbjs = window.$$PREBID_GLOBAL$$;
+export const c1xAdapter = {
+  code: BIDDER_CODE,
 
-  pbjs._c1xResponse = function(c1xResponse) {
-    var response = c1xResponse;
+  // check the bids sent to c1x bidder
+  isBidRequestValid: function(bid) {
+    const siteId = window.c1x_pubtag.siteId || '';
 
-    if (typeof response === 'string') {
-      try {
-        response = JSON.parse(c1xResponse);
-      } catch (error) {
-        utils.logError(error);
-      }
+    return (bid.adUnitCode && siteId);
+  },
+
+  buildRequests: function(bidRequests) {
+    let payload = {};
+    const siteId = window.c1x_pubtag.siteId || '';
+    const adunits = bidRequests.length;
+    const rid = new Date().getTime();
+
+    const c1xTags = bidRequests.map(bidToTag);
+    console.log('Show C1X Tags');
+    console.log(c1xTags);
+
+    payload = {
+      siteId: siteId,
+      adunits: adunits,
+      rid: rid,
     }
 
-    if (response && !response.error) {
-      for (var i = 0; i < response.length; i++) {
-        var data = response[i];
-        var bidObject = null;
-        if (data.bid) {
-          bidObject = bidfactory.createBid(CONSTANTS.STATUS.GOOD);
-          bidObject.bidderCode = BIDDER_CODE;
-          bidObject.cpm = data.cpm;
-          bidObject.ad = data.ad;
-          bidObject.width = data.width;
-          bidObject.height = data.height;
-          //TO DO
-          /** Required params
-          bidObject.id
-          bidObject.ttl
-          bidObject.creativeId
-          bidObject.netRevenue
-          bidObject.currency
-          **/
-          utils.logInfo(LOG_MSG.bidWin + data.adId + ' size: ' + data.width + 'x' + data.height);
-          bidmanager.addBidResponse(data.adId, bidObject);
-        } else {
-          // no bid
-          utils.logInfo(LOG_MSG.noBid + data.adId);
-          bidmanager.addBidResponse(data.adId, noBidResponse());
-        }
-      }
-    } else {
-      // invalid bid
-      var slots = pbjs.adUnits;
-      utils.logWarn(LOG_MSG.invalidBid);
-      for (i = 0; i < slots.length; i++) {
-        bidmanager.addBidResponse(slots[i].code, noBidResponse());
-      }
-    }
-  };
+    console.log(bidRequests);
+    let payloadString = 'site=1&adunits=1&a1=banner1&a1s=[728x90]&rid=1452866810&a1t=i&a1p=1.5';
+    payloadString = JSON.stringify(c1xTags);
+    console.log('Show Payload String: ');
+    console.log(payloadString);
 
-  function noBidResponse() {
-    var bidObject = bidfactory.createBid(CONSTANTS.STATUS.NO_BID);
-    bidObject.bidderCode = BIDDER_CODE;
-    return bidObject;
-  }
-
-  // inject the audience pixel only if bids.params.pixelId is set.
-  function injectAudiencePixel(pixel) {
-    var pixelId = pixel;
-    window.setTimeout(function() {
-      var pixel = document.createElement('img');
-      pixel.width = 1;
-      pixel.height = 1;
-      pixel.style = 'display:none;';
-      var useSSL = document.location.protocol;
-      pixel.src = (useSSL ? 'https:' : 'http:') + PIXEL_ENDPOINT + pixelId;
-      document.body.insertBefore(pixel, null);
-    }, PIXEL_FIRE_DELAY);
-  }
-
-  function _callBids(params) {
-    var bids = params.bids;
-    var c1xParams = bids[0].params;
-
-    if (c1xParams.pixelId) {
-      var pixelId = c1xParams.pixelId;
-      injectAudiencePixel(pixelId);
-    }
-
-    var siteId = c1xParams.siteId;
-    if (!siteId) {
-      utils.logWarn(LOG_MSG.noSite);
-      return;
-    }
-
-    var options = ['adunits=' + bids.length];
-    options.push('site=' + siteId);
-
-    for (var i = 0; i < bids.length; i++) {
-      options.push('a' + (i + 1) + '=' + bids[i].placementCode);
-      var sizes = bids[i].sizes;
-      var sizeStr = sizes.reduce(function(prev, current) { return prev + (prev === '' ? '' : ',') + current.join('x') }, '');
-      // send floor price if the setting is available.
-      var floorPriceMap = c1xParams.floorPriceMap;
-      if (floorPriceMap) {
-        var adUnitSize = sizes[0].join('x');
-        if (adUnitSize in floorPriceMap) {
-          options.push('a' + (i + 1) + 'p=' + floorPriceMap[adUnitSize]);
-        }
-      }
-      options.push('a' + (i + 1) + 's=[' + sizeStr + ']');
-    }
-    options.push('rid=' + new Date().getTime()); // cache busting
-    var c1xEndpoint = ENDPOINT;
-    if (c1xParams.endpoint) {
-      c1xEndpoint = c1xParams.endpoint;
-    }
-    var dspid = c1xParams.dspid;
-    if (dspid) {
-      options.push('dspid=' + dspid);
-    }
-    var url = c1xEndpoint + '?' + options.join('&');
-    window._c1xResponse = function (c1xResponse) {
-      pbjs._c1xResponse(c1xResponse);
+    return {
+      method: 'GET',
+      url: URL,
+      data: payloadString
     };
-    adloader.loadScript(url);
-  }
-  // Export the callBids function, so that prebid.js can execute this function
-  // when the page asks to send out bid requests.
-  return {
-    callBids: _callBids
-  };
-};
+  },
 
-adaptermanager.registerBidAdapter(new C1XAdapter(), 'c1x');
-module.exports = C1XAdapter;
+  // TO DO: Get JSON Responses from our bidder endpoint
+  interpretResponse: function(serverResponse, request) {
+    const bidResponses = [];
+    const bidResponse = {
+      requestId: '22222', // bidRequest.bidId,
+      bidderCode: 'c1x', // spec.code,
+      cpm: '2.5', // CPM,
+      width: '300', // WIDTH,
+      height: '250', // HEIGHT,
+      creativeId: '8999', // CREATIVE_ID,
+      dealId: '9999', // DEAL_ID,
+      currency: 'USD', // CURRENCY,
+      netRevenue: true,
+      ttl: '250', // TIME_TO_LIVE,
+      ad: '<html><h3>I am an ad</h3></html>', // CREATIVE_BODY
+    };
+    bidResponses.push(bidResponse);
+    return bidResponses;
+  },
+
+  getUserSyncs: function(syncOptions) {}
+}
+
+function bidToTag(bid, index) {
+  const tag = {};
+  const adIndex = 'a' + (index + 1).toString(); // ad unit id for c1x
+  const sizeKey = adIndex + 's';
+  // const priceKey = adIndex + 'p';
+  const sizesArr = bid.sizes;
+  tag[adIndex] = bid.adUnitCode;
+  tag[sizeKey] = sizesArr.reduce((prev, current) => prev + (prev === '' ? '' : ',') + current.join('x'), '');
+
+  return tag;
+}
+
+registerBidder(c1xAdapter);

--- a/modules/c1xBidAdapter.js
+++ b/modules/c1xBidAdapter.js
@@ -154,7 +154,6 @@ function bidToShortTag(bid) {
 
 function stringifyPayload(payload) {
   let payloadString = '';
-  console.log(payload);
   payloadString = JSON.stringify(payload).replace(/":"|","|{"|"}/g, (foundChar) => {
     if (foundChar == '":"') return '=';
     else if (foundChar == '","') return '&';

--- a/modules/c1xBidAdapter.js
+++ b/modules/c1xBidAdapter.js
@@ -1,0 +1,155 @@
+import CONSTANTS from 'src/constants.json';
+import utils from 'src/utils.js';
+import bidfactory from 'src/bidfactory.js';
+import bidmanager from 'src/bidmanager.js';
+import adloader from 'src/adloader';
+var adaptermanager = require('src/adaptermanager.js');
+
+/**
+ * Adapter for requesting bids from C1X header tag server.
+ * v2.0 (c) C1X Inc., 2017
+ *
+ * @param {Object} options - Configuration options for C1X
+ *
+ * @returns {{callBids: _callBids}}
+ * @constructor
+ */
+function C1XAdapter() {
+  // default endpoint. Can be overridden by adding an "endpoint" property to the first param in bidder config.
+  var ENDPOINT = 'http://ht-integration.c1exchange.com:9000/ht';
+  var PIXEL_ENDPOINT = '//px.c1exchange.com/pubpixel/';
+  var PIXEL_FIRE_DELAY = 3000;
+  var LOG_MSG = {
+    invalidBid: 'C1X: ERROR bidder returns an invalid bid',
+    noSite: 'C1X: ERROR no site id supplied',
+    noBid: 'C1X: INFO creating a NO bid for Adunit: ',
+    bidWin: 'C1X: INFO creating a bid for Adunit: '
+  };
+  var BIDDER_CODE = 'c1x';
+
+  var pbjs = window.$$PREBID_GLOBAL$$;
+
+  pbjs._c1xResponse = function(c1xResponse) {
+    var response = c1xResponse;
+
+    if (typeof response === 'string') {
+      try {
+        response = JSON.parse(c1xResponse);
+      } catch (error) {
+        utils.logError(error);
+      }
+    }
+
+    if (response && !response.error) {
+      for (var i = 0; i < response.length; i++) {
+        var data = response[i];
+        var bidObject = null;
+        if (data.bid) {
+          bidObject = bidfactory.createBid(CONSTANTS.STATUS.GOOD);
+          bidObject.bidderCode = BIDDER_CODE;
+          bidObject.cpm = data.cpm;
+          bidObject.ad = data.ad;
+          bidObject.width = data.width;
+          bidObject.height = data.height;
+          //TO DO
+          /** Required params
+          bidObject.id
+          bidObject.ttl
+          bidObject.creativeId
+          bidObject.netRevenue
+          bidObject.currency
+          **/
+          utils.logInfo(LOG_MSG.bidWin + data.adId + ' size: ' + data.width + 'x' + data.height);
+          bidmanager.addBidResponse(data.adId, bidObject);
+        } else {
+          // no bid
+          utils.logInfo(LOG_MSG.noBid + data.adId);
+          bidmanager.addBidResponse(data.adId, noBidResponse());
+        }
+      }
+    } else {
+      // invalid bid
+      var slots = pbjs.adUnits;
+      utils.logWarn(LOG_MSG.invalidBid);
+      for (i = 0; i < slots.length; i++) {
+        bidmanager.addBidResponse(slots[i].code, noBidResponse());
+      }
+    }
+  };
+
+  function noBidResponse() {
+    var bidObject = bidfactory.createBid(CONSTANTS.STATUS.NO_BID);
+    bidObject.bidderCode = BIDDER_CODE;
+    return bidObject;
+  }
+
+  // inject the audience pixel only if bids.params.pixelId is set.
+  function injectAudiencePixel(pixel) {
+    var pixelId = pixel;
+    window.setTimeout(function() {
+      var pixel = document.createElement('img');
+      pixel.width = 1;
+      pixel.height = 1;
+      pixel.style = 'display:none;';
+      var useSSL = document.location.protocol;
+      pixel.src = (useSSL ? 'https:' : 'http:') + PIXEL_ENDPOINT + pixelId;
+      document.body.insertBefore(pixel, null);
+    }, PIXEL_FIRE_DELAY);
+  }
+
+  function _callBids(params) {
+    var bids = params.bids;
+    var c1xParams = bids[0].params;
+
+    if (c1xParams.pixelId) {
+      var pixelId = c1xParams.pixelId;
+      injectAudiencePixel(pixelId);
+    }
+
+    var siteId = c1xParams.siteId;
+    if (!siteId) {
+      utils.logWarn(LOG_MSG.noSite);
+      return;
+    }
+
+    var options = ['adunits=' + bids.length];
+    options.push('site=' + siteId);
+
+    for (var i = 0; i < bids.length; i++) {
+      options.push('a' + (i + 1) + '=' + bids[i].placementCode);
+      var sizes = bids[i].sizes;
+      var sizeStr = sizes.reduce(function(prev, current) { return prev + (prev === '' ? '' : ',') + current.join('x') }, '');
+      // send floor price if the setting is available.
+      var floorPriceMap = c1xParams.floorPriceMap;
+      if (floorPriceMap) {
+        var adUnitSize = sizes[0].join('x');
+        if (adUnitSize in floorPriceMap) {
+          options.push('a' + (i + 1) + 'p=' + floorPriceMap[adUnitSize]);
+        }
+      }
+      options.push('a' + (i + 1) + 's=[' + sizeStr + ']');
+    }
+    options.push('rid=' + new Date().getTime()); // cache busting
+    var c1xEndpoint = ENDPOINT;
+    if (c1xParams.endpoint) {
+      c1xEndpoint = c1xParams.endpoint;
+    }
+    var dspid = c1xParams.dspid;
+    if (dspid) {
+      options.push('dspid=' + dspid);
+    }
+    var url = c1xEndpoint + '?' + options.join('&');
+    window._c1xResponse = function (c1xResponse) {
+      pbjs._c1xResponse(c1xResponse);
+    };
+    adloader.loadScript(url);
+  }
+  // Export the callBids function, so that prebid.js can execute this function
+  // when the page asks to send out bid requests.
+  return {
+    callBids: _callBids
+  };
+};
+
+adaptermanager.registerBidAdapter(new C1XAdapter(), 'c1x');
+module.exports = C1XAdapter;

--- a/modules/c1xBidAdapter.md
+++ b/modules/c1xBidAdapter.md
@@ -1,0 +1,38 @@
+# Overview
+
+Module Name: C1X Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: cathy@c1exchange.com
+
+# Description
+
+Module that connects to Example's demand sources
+
+# Test Parameters
+```
+    var adUnits = [
+           {
+               code: 'test-div',
+               sizes: [[300, 250]],  // a display size
+               bids: [
+                   {
+                       bidder: "example",
+                       params: {
+                           placement: '12345'
+                       }
+                   }
+               ]
+           },{
+               code: 'test-div',
+               sizes: [[300, 50]],   // a mobile size
+               bids: [
+                   {
+                       bidder: "example",
+                       params: {
+                           placement: 67890
+                       }
+                   }
+               ]
+           }
+       ];
+```

--- a/modules/c1xBidAdapter.md
+++ b/modules/c1xBidAdapter.md
@@ -10,29 +10,18 @@ Module that connects to Example's demand sources
 
 # Test Parameters
 ```
-    var adUnits = [
-           {
-               code: 'test-div',
-               sizes: [[300, 250]],  // a display size
-               bids: [
-                   {
-                       bidder: "example",
-                       params: {
-                           placement: '12345'
-                       }
-                   }
-               ]
-           },{
-               code: 'test-div',
-               sizes: [[300, 50]],   // a mobile size
-               bids: [
-                   {
-                       bidder: "example",
-                       params: {
-                           placement: 67890
-                       }
-                   }
-               ]
-           }
-       ];
+  var adUnits = [
+     {
+         code: 'test-div',
+         sizes: [[300, 250]],  // a display size
+         bids: [
+             {
+                 bidder: 'c1x',
+                 params: {
+                     placement: '12345'
+                 }
+             }
+         ]
+     },
+   ];
 ```

--- a/modules/c1xBidAdapter.md
+++ b/modules/c1xBidAdapter.md
@@ -6,19 +6,24 @@ Maintainer: cathy@c1exchange.com
 
 # Description
 
-Module that connects to Example's demand sources
+Module that connects to C1X's demand sources
 
 # Test Parameters
 ```
   var adUnits = [
      {
          code: 'test-div',
-         sizes: [[300, 250]],  // a display size
+         sizes: [[300, 600], [300, 250]],
          bids: [
              {
                  bidder: 'c1x',
                  params: {
-                     placement: '12345'
+                    siteId: '9999',
+                    pixelId: '12345',
+                    floorPriceMap: {
+                      '300x250': 0.20,
+                      '300x600': 0.30
+                    }, //optional
                  }
              }
          ]

--- a/test/spec/modules/c1xBidAdapter_spec.js
+++ b/test/spec/modules/c1xBidAdapter_spec.js
@@ -1,0 +1,186 @@
+import {expect} from 'chai';
+import C1XAdapter from 'modules/c1xBidAdapter';
+import bidmanager from 'src/bidmanager';
+import adLoader from 'src/adloader';
+
+let getDefaultBidRequest = () => {
+  return {
+    bidderCode: 'c1x',
+    bids: [{
+      bidder: 'c1x',
+      sizes: [[300, 250], [300, 600]],
+      params: {
+        siteId: '999',
+        pixelId: '9999',
+        placementCode: 'div-c1x-ht',
+        domain: 'http://c1exchange.com/'
+      }
+    }]
+  };
+};
+
+let getDefaultBidResponse = () => {
+  return {
+    bid: true,
+    adId: 'div-c1x-ht',
+    cpm: 3.31,
+    ad: '<div><a target=\"_new\" href=\"http://c1exchange.com\"><img src=\"https://placeholdit.imgix.net/~text?txtsize=38&txt=C1X%20Ad%20300x250&w=300&h=250&txttrack=0\"></a></div>',
+    width: 300,
+    height: 250
+  };
+};
+
+describe('c1x adapter tests: ', () => {
+  let pbjs = window.$$PREBID_GLOBAL$$ || {};
+  let stubLoadScript;
+  let adapter;
+
+  function createBidderRequest(bids) {
+    let bidderRequest = getDefaultBidRequest();
+    if (bids && Array.isArray(bids)) {
+      bidderRequest.bids = bids;
+    }
+    return bidderRequest;
+  }
+
+  beforeEach(() => {
+    adapter = new C1XAdapter();
+  });
+
+  describe('check callBids()', () => {
+    it('exists and is a function', () => {
+      expect(adapter.callBids).to.exist.and.to.be.a('function');
+    });
+  });
+  describe('creation of bid url', () => {
+    beforeEach(() => {
+      stubLoadScript = sinon.stub(adLoader, 'loadScript');
+    });
+    afterEach(() => {
+      stubLoadScript.restore();
+    });
+    it('should be called only once', () => {
+      adapter.callBids(getDefaultBidRequest());
+      sinon.assert.calledOnce(stubLoadScript);
+      expect(window._c1xResponse).to.exist.and.to.be.a('function');
+    });
+    it('require parameters before call', () => {
+      let xhr;
+      let requests;
+      xhr = sinon.useFakeXMLHttpRequest();
+      requests = [];
+      xhr.onCreate = request => requests.push(request);
+      adapter.callBids(getDefaultBidRequest());
+      expect(requests).to.be.empty;
+      xhr.restore();
+    });
+    it('should send with correct parameters', () => {
+      adapter.callBids(getDefaultBidRequest());
+      let expectedUrl = stubLoadScript.getCall(0).args[0];
+      sinon.assert.calledWith(stubLoadScript, expectedUrl);
+    });
+    it('should hit endpoint with optional param', () => {
+      let bids = [{
+        bidder: 'c1x',
+        sizes: [[300, 250], [300, 600]],
+        params: {
+          siteId: '999',
+          placementCode: 'div-c1x-ht',
+          endpoint: 'http://ht-integration.c1exchange.com:9000/ht',
+          floorPriceMap: {
+            '300x250': 4.00
+          },
+          dspid: '4288'
+        }
+      }];
+      adapter.callBids(createBidderRequest(bids));
+      let expectedUrl = stubLoadScript.getCall(0).args[0];
+      sinon.assert.calledWith(stubLoadScript, expectedUrl);
+      bids[0].sizes = [[728, 90]];
+      adapter.callBids(createBidderRequest(bids));
+      sinon.assert.calledTwice(stubLoadScript);
+    });
+    it('should hit default bidder endpoint', () => {
+      let bid = getDefaultBidRequest();
+      bid.bids[0].params.endpoint = null;
+      adapter.callBids(bid);
+      let expectedUrl = stubLoadScript.getCall(0).args[0];
+      sinon.assert.calledWith(stubLoadScript, expectedUrl);
+    });
+    it('should throw error msg if no site id provided', () => {
+      let bid = getDefaultBidRequest();
+      bid.bids[0].params.siteId = '';
+      adapter.callBids(bid);
+      sinon.assert.notCalled(stubLoadScript);
+    });
+    it('should not inject audience pixel if no pixelId provided', () => {
+      let bid = getDefaultBidRequest();
+      let responsePId;
+      bid.bids[0].params.pixelId = '';
+      adapter.callBids(bid);
+    });
+  });
+  describe('bid response', () => {
+    let server;
+    let stubAddBidResponse;
+    beforeEach(() => {
+      adapter = new C1XAdapter();
+      server = sinon.fakeServer.create();
+      stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
+    });
+
+    afterEach(() => {
+      server.restore();
+      stubAddBidResponse.restore();
+    });
+
+    it('callback function should exist', function () {
+      expect(pbjs._c1xResponse).to.exist.and.to.be.a('function');
+    });
+    it('should get JSONP from c1x bidder', function () {
+      let responses = [];
+      let stubC1XResponseFunc = sinon.stub(pbjs, '_c1xResponse');
+      responses.push(getDefaultBidResponse());
+      window._c1xResponse(JSON.stringify(responses));
+      sinon.assert.calledOnce(stubC1XResponseFunc);
+      stubC1XResponseFunc.restore();
+    });
+    it('should be added to bidmanager after returned from bidder', () => {
+      let responses = [];
+      responses.push(getDefaultBidResponse());
+      pbjs._c1xResponse(responses);
+      sinon.assert.calledOnce(stubAddBidResponse);
+    });
+    it('should send correct arguments to bidmanager.addBidResponse', () => {
+      let responses = [];
+      responses.push(getDefaultBidResponse());
+      pbjs._c1xResponse(JSON.stringify(responses));
+      var responseAdId = stubAddBidResponse.getCall(0).args[0];
+      var bidObject = stubAddBidResponse.getCall(0).args[1];
+      expect(responseAdId).to.equal('div-c1x-ht');
+      expect(bidObject.cpm).to.equal(3.31);
+      expect(bidObject.width).to.equal(300);
+      expect(bidObject.height).to.equal(250);
+      expect(bidObject.ad).to.equal('<div><a target=\"_new\" href=\"http://c1exchange.com\"><img src=\"https://placeholdit.imgix.net/~text?txtsize=38&txt=C1X%20Ad%20300x250&w=300&h=250&txttrack=0\"></a></div>');
+      expect(bidObject.bidderCode).to.equal('c1x');
+      sinon.assert.calledOnce(stubAddBidResponse);
+    });
+    it('should response to bidmanager when it is a no bid', () => {
+      let responses = [];
+      responses.push({'bid': false, 'adId': 'div-gpt-ad-1494499685685-0'});
+      pbjs._c1xResponse(responses);
+      let responseAdId = stubAddBidResponse.getCall(0).args[0];
+      let bidObject = stubAddBidResponse.getCall(0).args[1];
+      expect(responseAdId).to.equal('div-gpt-ad-1494499685685-0');
+      expect(bidObject.statusMessage).to.equal('Bid returned empty or error response');
+      sinon.assert.calledOnce(stubAddBidResponse);
+    });
+    it('should show error when bidder sends invalid bid responses', () => {
+      let responses;
+      pbjs._c1xResponse(responses);
+      let bidObject = stubAddBidResponse.getCall(0).args[1];
+      expect(bidObject.statusMessage).to.equal('Bid returned empty or error response');
+      sinon.assert.calledOnce(stubAddBidResponse);
+    });
+  });
+});

--- a/test/spec/modules/c1xBidAdapter_spec.js
+++ b/test/spec/modules/c1xBidAdapter_spec.js
@@ -17,30 +17,23 @@ describe('C1XAdapter', () => {
     let bid = {
       'bidder': 'c1x',
       'adUnitCode': 'adunit-code',
-      'sizes': [[300, 250], [300, 600]]
+      'sizes': [[300, 250], [300, 600]],
+      'params': {
+        'siteId': '9999'
+      }
     };
 
-    it('should return false when required params are not passed', () => {
-      let bid = Object.assign({}, bid);
-      global.window.c1x_pubtag.siteId = '';
-      console.log(global.window.location); // TO DO: check how to add attr to window obj
-      expect(c1xAdapter.isBidRequestValid(bid)).to.equal(false);
+    it('should return true when required params are passed', () => {
+      expect(c1xAdapter.isBidRequestValid(bid)).to.equal(true);
     });
-  });
 
-  describe('buildRequests', () => {
-    let bidRequests = [
-      {
-        'bidder': 'c1x',
-        'adUnitCode': 'adunit-code',
-        'sizes': [[300, 250], [300, 600]],
-      }
-    ];
-
-    it('sends bid request to ENDPOINT via GET', () => {
-      const request = c1xAdapter.buildRequests(bidRequests);
-      expect(request.url).to.equal(ENDPOINT);
-      expect(request.method).to.equal('GET');
+    it('should return false when required params are not found', () => {
+      let bid = Object.assign({}, bid);
+      delete bid.params;
+      bid.params = {
+        'siteId': null
+      };
+      expect(c1xAdapter.isBidRequestValid(bid)).to.equal(false);
     });
   });
 });

--- a/test/spec/modules/c1xBidAdapter_spec.js
+++ b/test/spec/modules/c1xBidAdapter_spec.js
@@ -1,186 +1,46 @@
-import {expect} from 'chai';
-import C1XAdapter from 'modules/c1xBidAdapter';
-import bidmanager from 'src/bidmanager';
-import adLoader from 'src/adloader';
+import { expect } from 'chai';
+import { c1xAdapter } from 'modules/c1xBidAdapter';
+import { newBidder } from 'src/adapters/bidderFactory';
 
-let getDefaultBidRequest = () => {
-  return {
-    bidderCode: 'c1x',
-    bids: [{
-      bidder: 'c1x',
-      sizes: [[300, 250], [300, 600]],
-      params: {
-        siteId: '999',
-        pixelId: '9999',
-        placementCode: 'div-c1x-ht',
-        domain: 'http://c1exchange.com/'
-      }
-    }]
-  };
-};
+const ENDPOINT = 'http://13.58.47.152:8080/ht';
 
-let getDefaultBidResponse = () => {
-  return {
-    bid: true,
-    adId: 'div-c1x-ht',
-    cpm: 3.31,
-    ad: '<div><a target=\"_new\" href=\"http://c1exchange.com\"><img src=\"https://placeholdit.imgix.net/~text?txtsize=38&txt=C1X%20Ad%20300x250&w=300&h=250&txttrack=0\"></a></div>',
-    width: 300,
-    height: 250
-  };
-};
+describe('C1XAdapter', () => {
+  const adapter = newBidder(c1xAdapter);
 
-describe('c1x adapter tests: ', () => {
-  let pbjs = window.$$PREBID_GLOBAL$$ || {};
-  let stubLoadScript;
-  let adapter;
-
-  function createBidderRequest(bids) {
-    let bidderRequest = getDefaultBidRequest();
-    if (bids && Array.isArray(bids)) {
-      bidderRequest.bids = bids;
-    }
-    return bidderRequest;
-  }
-
-  beforeEach(() => {
-    adapter = new C1XAdapter();
-  });
-
-  describe('check callBids()', () => {
+  describe('inherited functions', () => {
     it('exists and is a function', () => {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
-  describe('creation of bid url', () => {
-    beforeEach(() => {
-      stubLoadScript = sinon.stub(adLoader, 'loadScript');
-    });
-    afterEach(() => {
-      stubLoadScript.restore();
-    });
-    it('should be called only once', () => {
-      adapter.callBids(getDefaultBidRequest());
-      sinon.assert.calledOnce(stubLoadScript);
-      expect(window._c1xResponse).to.exist.and.to.be.a('function');
-    });
-    it('require parameters before call', () => {
-      let xhr;
-      let requests;
-      xhr = sinon.useFakeXMLHttpRequest();
-      requests = [];
-      xhr.onCreate = request => requests.push(request);
-      adapter.callBids(getDefaultBidRequest());
-      expect(requests).to.be.empty;
-      xhr.restore();
-    });
-    it('should send with correct parameters', () => {
-      adapter.callBids(getDefaultBidRequest());
-      let expectedUrl = stubLoadScript.getCall(0).args[0];
-      sinon.assert.calledWith(stubLoadScript, expectedUrl);
-    });
-    it('should hit endpoint with optional param', () => {
-      let bids = [{
-        bidder: 'c1x',
-        sizes: [[300, 250], [300, 600]],
-        params: {
-          siteId: '999',
-          placementCode: 'div-c1x-ht',
-          endpoint: 'http://ht-integration.c1exchange.com:9000/ht',
-          floorPriceMap: {
-            '300x250': 4.00
-          },
-          dspid: '4288'
-        }
-      }];
-      adapter.callBids(createBidderRequest(bids));
-      let expectedUrl = stubLoadScript.getCall(0).args[0];
-      sinon.assert.calledWith(stubLoadScript, expectedUrl);
-      bids[0].sizes = [[728, 90]];
-      adapter.callBids(createBidderRequest(bids));
-      sinon.assert.calledTwice(stubLoadScript);
-    });
-    it('should hit default bidder endpoint', () => {
-      let bid = getDefaultBidRequest();
-      bid.bids[0].params.endpoint = null;
-      adapter.callBids(bid);
-      let expectedUrl = stubLoadScript.getCall(0).args[0];
-      sinon.assert.calledWith(stubLoadScript, expectedUrl);
-    });
-    it('should throw error msg if no site id provided', () => {
-      let bid = getDefaultBidRequest();
-      bid.bids[0].params.siteId = '';
-      adapter.callBids(bid);
-      sinon.assert.notCalled(stubLoadScript);
-    });
-    it('should not inject audience pixel if no pixelId provided', () => {
-      let bid = getDefaultBidRequest();
-      let responsePId;
-      bid.bids[0].params.pixelId = '';
-      adapter.callBids(bid);
+
+  describe('isBidRequestValid', () => {
+    let bid = {
+      'bidder': 'c1x',
+      'adUnitCode': 'adunit-code',
+      'sizes': [[300, 250], [300, 600]]
+    };
+
+    it('should return false when required params are not passed', () => {
+      let bid = Object.assign({}, bid);
+      global.window.c1x_pubtag.siteId = '';
+      console.log(global.window.location); // TO DO: check how to add attr to window obj
+      expect(c1xAdapter.isBidRequestValid(bid)).to.equal(false);
     });
   });
-  describe('bid response', () => {
-    let server;
-    let stubAddBidResponse;
-    beforeEach(() => {
-      adapter = new C1XAdapter();
-      server = sinon.fakeServer.create();
-      stubAddBidResponse = sinon.stub(bidmanager, 'addBidResponse');
-    });
 
-    afterEach(() => {
-      server.restore();
-      stubAddBidResponse.restore();
-    });
+  describe('buildRequests', () => {
+    let bidRequests = [
+      {
+        'bidder': 'c1x',
+        'adUnitCode': 'adunit-code',
+        'sizes': [[300, 250], [300, 600]],
+      }
+    ];
 
-    it('callback function should exist', function () {
-      expect(pbjs._c1xResponse).to.exist.and.to.be.a('function');
-    });
-    it('should get JSONP from c1x bidder', function () {
-      let responses = [];
-      let stubC1XResponseFunc = sinon.stub(pbjs, '_c1xResponse');
-      responses.push(getDefaultBidResponse());
-      window._c1xResponse(JSON.stringify(responses));
-      sinon.assert.calledOnce(stubC1XResponseFunc);
-      stubC1XResponseFunc.restore();
-    });
-    it('should be added to bidmanager after returned from bidder', () => {
-      let responses = [];
-      responses.push(getDefaultBidResponse());
-      pbjs._c1xResponse(responses);
-      sinon.assert.calledOnce(stubAddBidResponse);
-    });
-    it('should send correct arguments to bidmanager.addBidResponse', () => {
-      let responses = [];
-      responses.push(getDefaultBidResponse());
-      pbjs._c1xResponse(JSON.stringify(responses));
-      var responseAdId = stubAddBidResponse.getCall(0).args[0];
-      var bidObject = stubAddBidResponse.getCall(0).args[1];
-      expect(responseAdId).to.equal('div-c1x-ht');
-      expect(bidObject.cpm).to.equal(3.31);
-      expect(bidObject.width).to.equal(300);
-      expect(bidObject.height).to.equal(250);
-      expect(bidObject.ad).to.equal('<div><a target=\"_new\" href=\"http://c1exchange.com\"><img src=\"https://placeholdit.imgix.net/~text?txtsize=38&txt=C1X%20Ad%20300x250&w=300&h=250&txttrack=0\"></a></div>');
-      expect(bidObject.bidderCode).to.equal('c1x');
-      sinon.assert.calledOnce(stubAddBidResponse);
-    });
-    it('should response to bidmanager when it is a no bid', () => {
-      let responses = [];
-      responses.push({'bid': false, 'adId': 'div-gpt-ad-1494499685685-0'});
-      pbjs._c1xResponse(responses);
-      let responseAdId = stubAddBidResponse.getCall(0).args[0];
-      let bidObject = stubAddBidResponse.getCall(0).args[1];
-      expect(responseAdId).to.equal('div-gpt-ad-1494499685685-0');
-      expect(bidObject.statusMessage).to.equal('Bid returned empty or error response');
-      sinon.assert.calledOnce(stubAddBidResponse);
-    });
-    it('should show error when bidder sends invalid bid responses', () => {
-      let responses;
-      pbjs._c1xResponse(responses);
-      let bidObject = stubAddBidResponse.getCall(0).args[1];
-      expect(bidObject.statusMessage).to.equal('Bid returned empty or error response');
-      sinon.assert.calledOnce(stubAddBidResponse);
+    it('sends bid request to ENDPOINT via GET', () => {
+      const request = c1xAdapter.buildRequests(bidRequests);
+      expect(request.url).to.equal(ENDPOINT);
+      expect(request.method).to.equal('GET');
     });
   });
 });

--- a/test/spec/modules/c1xBidAdapter_spec.js
+++ b/test/spec/modules/c1xBidAdapter_spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { c1xAdapter } from 'modules/c1xBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
 
-const ENDPOINT = 'http://13.58.47.152:8080/ht';
+const ENDPOINT = 'http://18.217.214.190:8080/ht';
 const BIDDER_CODE = 'c1x';
 
 describe('C1XAdapter', () => {
@@ -124,7 +124,8 @@ describe('C1XAdapter', () => {
       'width': 300,
       'height': 250,
       'crid': '8888',
-      'adId': 'c1x-test'
+      'adId': 'c1x-test',
+      'bidType': 'GROSS_BID'
     };
 
     it('should get correct bid response', () => {


### PR DESCRIPTION
Adapter Code is done and tested with my test page. Please **Close** this PR once the code review is done. The adapter branch now has Prebid 1.0 codes but I can only send our changed files with Prebid master as a base. Will sort things out and send another PR to Prebid.org.

A few questions here:
1. siteId/ pixelId/ endpoint settings.
> All adapters must support the creation of multiple concurrent instances. This means, for example, that adapters cannot rely on mutable global variables. - from Prebid website

I am not sure if it is ok to use our own tag under window object. I implemented window.c1x_pubtag in order to follow the internal requirement which is avoid redundancy of bid params in ad units. Ex: the same site id has to be filled in each ad units on a webpage.

Just found out this PR discussion... https://github.com/prebid/Prebid.js/pull/1664
I might need to update our adapter to meet Prebid v1.0 requirements soon.

2. cpm bid price from our bidder - Net or Gross?
To confirm _netRevenue_ in bid response object

3. window obj not exists in automated testing... I didn't find a good way after a full day of research. Any suggestions?
Finding: 
- the unit tests are run in headless chrome by default. Headless chrome doesn't actually has a window or browser viewport. But our common params are put as a key of window object...


# Test Steps

1. $ gulp build --modules=c1xBidAdapter
2.  confirm the build file location on the test page
pbs.src = '../../build/dist/prebid.js';
3. open test page, you should be able to see one ad showing up on the page

